### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,12 +1,12 @@
 PathVariableHandler	KEYWORD1
-TokenIterator       KEYWORD1
-UrlTokenBindings    KEYWORD1
+TokenIterator	KEYWORD1
+UrlTokenBindings	KEYWORD1
 
-hasBinding          KEYWORD2
-get                 KEYWORD2
-hasNext             KEYWORD2
-next                KEYWORD2
-canHandle           KEYWORD2
-handle              KEYWORD2
-handleRequest       KEYWORD2
-handleBody          KEYWORD2
+hasBinding	KEYWORD2
+get	KEYWORD2
+hasNext	KEYWORD2
+next	KEYWORD2
+canHandle	KEYWORD2
+handle	KEYWORD2
+handleRequest	KEYWORD2
+handleBody	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords