### PR TITLE
Create copy of buffer, use std::shared_ptr

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,36 @@
+name: Build
+
+on: [push]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        board: [d1_mini, esp32doit-devkit-v1]
+        source: [Simple]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+            .pio/build
+          key: ${{ runner.os }}-pio
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Install PlatformIO Core
+        run: |
+          pip install -U platformio
+          pio pkg update
+
+      - name: Build PlatformIO
+        run: |
+          pio ci \
+            --board=${{ matrix.board }} \
+            --lib=. \
+          examples/${{ matrix.source }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,14 +1,9 @@
-name: Build
+name: Build and test
 
 on: [push]
 
 jobs:
   build:
-    strategy:
-      matrix:
-        board: [d1_mini, esp32doit-devkit-v1]
-        source: [Simple]
-
     runs-on: ubuntu-latest
 
     steps:
@@ -28,9 +23,19 @@ jobs:
           pip install -U platformio
           pio pkg update
 
-      - name: Build PlatformIO
+      - name: Run unit tests
+        run: pio test
+
+      - name: Build example source for ESP8266
         run: |
           pio ci \
-            --board=${{ matrix.board }} \
+            --board=d1_mini \
             --lib=. \
-          examples/${{ matrix.source }}
+          examples/Simple
+
+      - name: Build example source for ESP32
+        run: |
+          pio ci \
+            --board=esp32doit-devkit-v1 \
+            --lib=. \
+          examples/Simple

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
+    environment:
+      name: release
+
     steps:
       - name: Create Release
         uses: actions/github-script@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,45 @@
+name: Publish Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create Release
+        uses: actions/github-script@v2
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const fs = require('fs').promises;
+            
+            const { repo: { owner, repo }, sha } = context;
+            console.log({ owner, repo, sha });
+
+            const release = await github.repos.createRelease({
+              owner, repo,
+              name: process.env.GITHUB_REF_NAME,
+              tag_name: process.env.GITHUB_REF,
+              draft: true,
+              target_commitish: sha
+            });
+
+  publish_pio_package:
+    runs-on: ubuntu-latest
+
+    environment:
+      name: release
+
+    env:
+      PLATFORMIO_AUTH_TOKEN: ${{secrets.PLATFORMIO_AUTH_TOKEN}}
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+      - name: Publish PlatformIO Package
+        run: python3 -m platformio pkg publish --no-interactive

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .vscode/.browse.c_cpp.db*
 .vscode/c_cpp_properties.json
 .vscode/launch.json
+.pio

--- a/examples/Simple/Simple.ino
+++ b/examples/Simple/Simple.ino
@@ -9,8 +9,8 @@ void setup() {
   char p1[] = "example/path/a/b/c";
   char p2[] = "example/path/:var1/:var2/:var3";
 
-  TokenIterator itr1(p1, strlen(p1), '/');
-  TokenIterator itr2(p2, strlen(p2), '/');
+  auto itr1 = std::make_shared<TokenIterator>(p1, strlen(p1), '/');
+  auto itr2 = std::make_shared<TokenIterator>(p2, strlen(p2), '/');
   UrlTokenBindings bindings(itr1, itr2);
 
   if (bindings.hasBinding("var1")) {      // has this one

--- a/examples/Simple/Simple.ino
+++ b/examples/Simple/Simple.ino
@@ -6,12 +6,11 @@
 void setup() {
   Serial.begin(115200);
 
-  char p1[] = "example/path/a/b/c";
-  char p2[] = "example/path/:var1/:var2/:var3";
+  char templatePath[] = "example/path/:var1/:var2/:var3";
+  char samplePath[] = "example/path/a/b/c";
 
-  auto itr1 = std::make_shared<TokenIterator>(p1, strlen(p1), '/');
-  auto itr2 = std::make_shared<TokenIterator>(p2, strlen(p2), '/');
-  UrlTokenBindings bindings(itr1, itr2);
+  auto templateItr = std::make_shared<TokenIterator>(templatePath, strlen(templatePath), '/');
+  UrlTokenBindings bindings(templateItr, samplePath);
 
   if (bindings.hasBinding("var1")) {      // has this one
     Serial.println(bindings.get("var1")); // will print "a"

--- a/library.json
+++ b/library.json
@@ -18,7 +18,7 @@
   ],
   "license": "MIT",
   "dependencies": { },
-  "version": "2.0.0",
+  "version": "3.0.0",
   "frameworks": "arduino",
   "platforms": "*",
   "examples": "examples/*/*.ino",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=PathVariableHandlers
-version=2.0.0
+version=3.0.0
 author=Chris Mullins <chris@sidoh.org>
 maintainer=Chris Mullins <chris@sidoh.org>
 sentence=Library for handling paths containing variables.

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,7 +1,4 @@
-[env:native]
+[env:test]
 platform = native
-test_build_project_src = true
-lib_ignore =
-  ESPAsyncTCP
-  AsyncTCP
-  ESP Async WebServer
+test_build_src = true
+test_framework = unity

--- a/src/TokenIterator.cpp
+++ b/src/TokenIterator.cpp
@@ -1,5 +1,5 @@
 #include <TokenIterator.h>
-#include <Arduino.h>
+#include <cstring>
 
 TokenIterator::TokenIterator(const char* data, size_t length, const char sep)
   : data(new char[length+1]),

--- a/src/TokenIterator.cpp
+++ b/src/TokenIterator.cpp
@@ -1,22 +1,25 @@
 #include <TokenIterator.h>
+#include <Arduino.h>
 
-TokenIterator::TokenIterator(char* data, size_t length, const char sep)
-  : data(data),
-    current(data),
+TokenIterator::TokenIterator(const char* data, size_t length, const char sep)
+  : data(new char[length+1]),
+    current(this->data),
     length(length),
-    sep(sep),
     i(0)
 {
-  for (size_t i = 0; i < length; i++) {
-    if (data[i] == sep) {
-      data[i] = 0;
+  strncpy(this->data, data, length);
+  this->data[length] = 0;
+
+  for (size_t ix = 0; ix < length; ix++) {
+    if (this->data[ix] == sep) {
+      this->data[ix] = 0;
     }
   }
 }
 
 const char* TokenIterator::nextToken() {
   if (i >= length) {
-    return NULL;
+    return nullptr;
   }
 
   char* token = current;
@@ -25,14 +28,14 @@ const char* TokenIterator::nextToken() {
   for (; i < length && *nextToken != 0; i++, nextToken++);
 
   if (i == length) {
-    nextToken = NULL;
+    nextToken = nullptr;
   } else {
     i = (nextToken - data);
 
     if (i < length) {
       nextToken++;
     } else {
-      nextToken = NULL;
+      nextToken = nullptr;
     }
   }
 
@@ -48,4 +51,8 @@ void TokenIterator::reset() {
 
 bool TokenIterator::hasNext() {
   return i < length;
+}
+
+TokenIterator::~TokenIterator() {
+  delete[] data;
 }

--- a/src/TokenIterator.h
+++ b/src/TokenIterator.h
@@ -5,7 +5,8 @@
 
 class TokenIterator {
 public:
-  TokenIterator(char* data, size_t length, char sep = ',');
+  TokenIterator(const char* data, size_t length, char sep = ',');
+  ~TokenIterator();
 
   bool hasNext();
   const char* nextToken();
@@ -15,7 +16,6 @@ private:
   char* data;
   char* current;
   size_t length;
-  char sep;
   size_t i;
 };
 

--- a/src/TokenIterator.h
+++ b/src/TokenIterator.h
@@ -5,7 +5,7 @@
 
 class TokenIterator {
 public:
-  TokenIterator(const char* data, size_t length, char sep = ',');
+  TokenIterator(const char* data, size_t length, char sep = '/');
   ~TokenIterator();
 
   bool hasNext();

--- a/src/UrlTokenBindings.cpp
+++ b/src/UrlTokenBindings.cpp
@@ -11,6 +11,13 @@ UrlTokenBindings::UrlTokenBindings(
     requestTokens(std::move(requestTokens))
 { }
 
+UrlTokenBindings::UrlTokenBindings(
+    std::shared_ptr<TokenIterator> patternTokens,
+    const char *requestPath
+): patternTokens(std::move(patternTokens)),
+   requestTokens(std::make_shared<TokenIterator>(requestPath, strlen(requestPath), '/'))
+{ }
+
 bool UrlTokenBindings::hasBinding(const char* searchToken) const {
   patternTokens->reset();
 

--- a/src/UrlTokenBindings.cpp
+++ b/src/UrlTokenBindings.cpp
@@ -1,15 +1,22 @@
 #include <string.h>
 #include <UrlTokenBindings.h>
+#include <Arduino.h>
 
-UrlTokenBindings::UrlTokenBindings(TokenIterator& patternTokens, TokenIterator& requestTokens)
-  : patternTokens(patternTokens),
-    requestTokens(requestTokens)
+#include <memory>
+#include <utility>
+
+UrlTokenBindings::UrlTokenBindings(
+    std::shared_ptr<TokenIterator> patternTokens,
+    std::shared_ptr<TokenIterator> requestTokens
+) : patternTokens(std::move(patternTokens)),
+    requestTokens(std::move(requestTokens))
 { }
 
 bool UrlTokenBindings::hasBinding(const char* searchToken) const {
-  patternTokens.reset();
-  while (patternTokens.hasNext()) {
-    const char* token = patternTokens.nextToken();
+  patternTokens->reset();
+
+  while (patternTokens->hasNext()) {
+    const char* token = patternTokens->nextToken();
 
     if (token[0] == ':' && strcmp(token+1, searchToken) == 0) {
       return true;
@@ -20,17 +27,17 @@ bool UrlTokenBindings::hasBinding(const char* searchToken) const {
 }
 
 const char* UrlTokenBindings::get(const char* searchToken) const {
-  patternTokens.reset();
-  requestTokens.reset();
+  patternTokens->reset();
+  requestTokens->reset();
 
-  while (patternTokens.hasNext() && requestTokens.hasNext()) {
-    const char* token = patternTokens.nextToken();
-    const char* binding = requestTokens.nextToken();
+  while (patternTokens->hasNext() && requestTokens->hasNext()) {
+    const char* token = patternTokens->nextToken();
+    const char* binding = requestTokens->nextToken();
 
     if (token[0] == ':' && strcmp(token+1, searchToken) == 0) {
       return binding;
     }
   }
 
-  return NULL;
+  return nullptr;
 }

--- a/src/UrlTokenBindings.cpp
+++ b/src/UrlTokenBindings.cpp
@@ -1,6 +1,5 @@
 #include <string.h>
 #include <UrlTokenBindings.h>
-#include <Arduino.h>
 
 #include <memory>
 #include <utility>

--- a/src/UrlTokenBindings.h
+++ b/src/UrlTokenBindings.h
@@ -11,6 +11,10 @@ public:
       std::shared_ptr<TokenIterator> patternTokens,
       std::shared_ptr<TokenIterator> requestTokens
   );
+  UrlTokenBindings(
+      std::shared_ptr<TokenIterator> patternTokens,
+      const char* requestPath
+  );
 
   bool hasBinding(const char* key) const;
   const char* get(const char* key) const;

--- a/src/UrlTokenBindings.h
+++ b/src/UrlTokenBindings.h
@@ -1,18 +1,23 @@
 #include <TokenIterator.h>
 
+#include <memory>
+
 #ifndef _URL_TOKEN_BINDINGS_H
 #define _URL_TOKEN_BINDINGS_H
 
 class UrlTokenBindings {
 public:
-  UrlTokenBindings(TokenIterator& patternTokens, TokenIterator& requestTokens);
+  UrlTokenBindings(
+      std::shared_ptr<TokenIterator> patternTokens,
+      std::shared_ptr<TokenIterator> requestTokens
+  );
 
   bool hasBinding(const char* key) const;
   const char* get(const char* key) const;
 
 private:
-  TokenIterator& patternTokens;
-  TokenIterator& requestTokens;
+  std::shared_ptr<TokenIterator> patternTokens;
+  std::shared_ptr<TokenIterator> requestTokens;
 };
 
 #endif

--- a/test/test_url_token_bindings/test_url_token_bindings.cpp
+++ b/test/test_url_token_bindings/test_url_token_bindings.cpp
@@ -22,13 +22,30 @@ void test_simple(void) {
   TEST_ASSERT_EQUAL_STRING("456", bindings.get("c"));
 }
 
+void test_path_constructor(void) {
+  strcpy(buffer1, "a/:b/:c");
+  strcpy(buffer2, "a/123/456");
+
+  auto itr1 = std::make_shared<TokenIterator>(buffer1, strlen(buffer1), '/');
+
+  UrlTokenBindings bindings(itr1, buffer2);
+
+  TEST_ASSERT_EQUAL(false, bindings.hasBinding("a"));
+  TEST_ASSERT_EQUAL(true, bindings.hasBinding("b"));
+  TEST_ASSERT_EQUAL(true, bindings.hasBinding("c"));
+
+  TEST_ASSERT_EQUAL_STRING("123", bindings.get("b"));
+  TEST_ASSERT_EQUAL_STRING("456", bindings.get("c"));
+}
+
 void process() {
-    UNITY_BEGIN();
-    RUN_TEST(test_simple);
-    UNITY_END();
+  UNITY_BEGIN();
+  RUN_TEST(test_simple);
+  RUN_TEST(test_path_constructor);
+  UNITY_END();
 }
 
 int main(int argc, char **argv) {
-    process();
-    return 0;
+  process();
+  return 0;
 }

--- a/test/test_url_token_bindings/test_url_token_bindings.cpp
+++ b/test/test_url_token_bindings/test_url_token_bindings.cpp
@@ -9,8 +9,8 @@ void test_simple(void) {
   strcpy(buffer1, "a/:b/:c");
   strcpy(buffer2, "a/123/456");
 
-  TokenIterator itr1(buffer1, strlen(buffer1), '/');
-  TokenIterator itr2(buffer2, strlen(buffer2), '/');
+  auto itr1 = std::make_shared<TokenIterator>(buffer1, strlen(buffer1), '/');
+  auto itr2 = std::make_shared<TokenIterator>(buffer2, strlen(buffer2), '/');
 
   UrlTokenBindings bindings(itr1, itr2);
 


### PR DESCRIPTION
## Changes

* Breaking change to interface: `UrlTokenBindings` now takes `std::shared_ptr<TokenIterator>` instead of references
* `TokenIterator` now creates a copy of the path it's passed